### PR TITLE
Feat/cse 326 remove target page filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ public
 coverage
 reports
 settings.json
+.cache
 
 # IntelliJ Idea	
 .idea/

--- a/src/pages/Target/index.spec.tsx
+++ b/src/pages/Target/index.spec.tsx
@@ -37,13 +37,13 @@ describe('Target Page', () => {
   });
 
   it('parses breadcrumb data from a claim', () => {
-    const parsedBreadCrumbData = parseBreadCrumbData(ELAG3ClaimMock, 0);
+    const parsedBreadCrumbData = parseBreadCrumbData(ELAG3ClaimMock);
 
     expect(parsedBreadCrumbData).toEqual(parsedBreadCrumbDataMock);
   });
 
   it('parses title bar data from a claim', () => {
-    const parsedTitleBarData = parseTitleBarData(ELAG3ClaimMock, 0);
+    const parsedTitleBarData = parseTitleBarData(ELAG3ClaimMock);
 
     expect(parsedTitleBarData).toEqual(parsedTitleBarDataMock);
   });

--- a/src/pages/Target/index.tsx
+++ b/src/pages/Target/index.tsx
@@ -97,22 +97,22 @@ export const parseNavProps = (target: ITarget): ItemProps[] => {
   return items;
 };
 
-export const parseBreadCrumbData = (claim: IClaim, targetIndex: number): BreadcrumbsProps => {
+export const parseBreadCrumbData = (claim: IClaim): BreadcrumbsProps => {
   return {
     subject: claim.subject,
     grade: `Grade ${claim.grades}`,
     claim: claim.claimNumber,
-    target: claim.target[targetIndex].title
+    target: claim.target[0].title
   };
 };
 
-export const parseTitleBarData = (claim: IClaim, targetIndex: number): TitleBarProps => {
+export const parseTitleBarData = (claim: IClaim): TitleBarProps => {
   return {
     claimTitle: claim.claimNumber,
     claimDesc: claim.description,
     downloadBtnProps: downloadBtnMock,
-    targetTitle: claim.target[targetIndex].title,
-    targetDesc: claim.target[targetIndex].description
+    targetTitle: claim.target[0].title,
+    targetDesc: claim.target[0].description
   };
 };
 
@@ -177,8 +177,6 @@ export class TargetPage extends Component<TargetPageProps, TargetPageState> {
   componentWillMount() {
     let test: ITargetParams;
     const { targetShortCode }: MatchParams = this.props.match.params;
-    const splitCode = targetShortCode.split('.')[3].match(/\d+$/);
-    const targetCode = splitCode && parseInt(splitCode[0], 10);
     if (!this.props.match || !this.props.match.params) {
       test = {
         targetShortCode: ''
@@ -191,13 +189,13 @@ export class TargetPage extends Component<TargetPageProps, TargetPageState> {
     this.targetClient
       .getTarget(test)
       .then(data => {
-        if (data !== undefined && targetCode !== null) {
+        if (data !== undefined) {
           const claimData = (data as unknown) as IClaim;
           this.setState({
             claim: claimData,
-            target: claimData.target[targetCode - 1],
-            breadCrumbProps: parseBreadCrumbData(claimData, targetCode - 1),
-            titleBarProps: parseTitleBarData(claimData, targetCode - 1)
+            target: claimData.target[0],
+            breadCrumbProps: parseBreadCrumbData(claimData),
+            titleBarProps: parseTitleBarData(claimData)
           });
         }
       })


### PR DESCRIPTION
# Changes introduced

This removes the logic for selecting the proper target out of a list. The list now contains only one target so it is easily selected.

## Related issue(s):

- CSE-326

## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [x] Added new stories for created/modified components (if applicable)
- [x] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [ ] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [x] Assigned yourself to the PR
- [x] Read through the changes in the `Files changed` tab
- [x] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
