### PR TITLE
fix(deployment): support SPA routing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           command: docker login -u $DOCKER_USER -p $DOCKER_PASS
       - run:
           name: Build image
-          command: 'docker build -t osucass/content-specification-explorer-app:$TAG_VERSION -f Dockerfile-prod .'
+          command: 'docker build -t osucass/content-specification-explorer-app:$TAG_VERSION -f build/Dockerfile .'
       - run:
           name: Push image to Docker Hub
           command: 'docker push osucass/content-specification-explorer-app:$TAG_VERSION'

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,4 +11,5 @@ ENV NODE_ENV production
 RUN npm run build
 
 FROM nginx:alpine
+COPY build/nginx.conf /etc/nginx/nginx.conf
 COPY --from=build-env /app/dist /usr/share/nginx/html

--- a/build/nginx.conf
+++ b/build/nginx.conf
@@ -1,0 +1,39 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    server {
+        listen       80;
+        server_name  localhost;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+            try_files $uri $uri/ /index.html;
+        }
+    }
+
+    #gzip  on;
+
+}


### PR DESCRIPTION
# Changes introduced

The out-of-the-box Docker image we are using to host the SPA within our Kubernetes configuration was not set up to handle SPA routing; if the user were to refresh a page, the browser would make a request for that route to the NGiNX server, and then receive a 404.

To resolve this, we now hand in a custom NGiNX configuration that redirects all 404s back to the root `index.html`, which will allow the client to resolve the requested route, in the event of a page refresh.

## Related issue(s):

## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [ ] Added new stories for created/modified components (if applicable)
- [ ] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
