### PR TITLE
Fix/cse 353 update help page links

### DIFF
--- a/src/components/HelpContent/__snapshots__/index.storybook.storyshot
+++ b/src/components/HelpContent/__snapshots__/index.storybook.storyshot
@@ -20,6 +20,8 @@ exports[`Storyshots Help Content accessibility 1`] = `
   <p>
     <a
       href="https://portal.smarterbalanced.org/library/en/accessibility-accommodations-fact-sheet.pdf"
+      rel="noopener noreferrer"
+      target="_blank"
     >
       Accessibility and Accommodations Fact Sheet
     </a>
@@ -29,12 +31,28 @@ exports[`Storyshots Help Content accessibility 1`] = `
      
     <a
       href="http://www.smarterbalanced.org/assessments/accessibility-and-accommodations/"
+      rel="noopener noreferrer"
+      target="_blank"
     >
       accessibility and accommodations
     </a>
      
     can be found on the Smarter Balanced website.
   </p>
+  <style
+    jsx={true}
+  >
+    
+    a {
+      color: #007393;
+    }
+    a:hover,
+    a:active {
+      color: #111213;
+      text-decoration: none;
+    }
+  
+  </style>
 </div>
 `;
 
@@ -55,6 +73,8 @@ exports[`Storyshots Help Content claims 1`] = `
        
       <a
         href="https://portal.smarterbalanced.org/library/en/claims-for-the-ela-literacy-summative-assessments.pdf"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         content claims
       </a>
@@ -65,12 +85,28 @@ exports[`Storyshots Help Content claims 1`] = `
        
       <a
         href="https://portal.smarterbalanced.org/library/en/claims-for-the-mathematics-summative-assessments.pdf"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         content claims:
       </a>
        
       Concepts and Procedures, Problem Solving, Communicating Reasoning, and Modeling and Data Analysis
     </li>
+    <style
+      jsx={true}
+    >
+      
+    a {
+      color: #007393;
+    }
+    a:hover,
+    a:active {
+      color: #111213;
+      text-decoration: none;
+    }
+  
+    </style>
   </ul>
 </div>
 `;
@@ -89,6 +125,8 @@ exports[`Storyshots Help Content content spec 1`] = `
        
       <a
         href="https://portal.smarterbalanced.org/library/en/english-language-artsliteracy-content-specifications.pdf"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         English language arts/literacy
       </a>
@@ -97,6 +135,8 @@ exports[`Storyshots Help Content content spec 1`] = `
        
       <a
         href="https://portal.smarterbalanced.org/library/en/mathematics-content-specifications.pdf"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         mathematics
       </a>
@@ -109,6 +149,8 @@ exports[`Storyshots Help Content content spec 1`] = `
         <li>
           <a
             href="https://www.smarterbalancedlibrary.org/content/understanding-smarter-balanced-mathematics-content-specifications"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             Mathematics
           </a>
@@ -116,12 +158,28 @@ exports[`Storyshots Help Content content spec 1`] = `
         <li>
           <a
             href="https://www.smarterbalancedlibrary.org/content/understanding-smarter-balanced-elaliteracy-content-specifications"
+            rel="noopener noreferrer"
+            target="_blank"
           >
             English language arts/literacy
           </a>
         </li>
       </ul>
     </li>
+    <style
+      jsx={true}
+    >
+      
+    a {
+      color: #007393;
+    }
+    a:hover,
+    a:active {
+      color: #111213;
+      text-decoration: none;
+    }
+  
+    </style>
   </ul>
 </div>
 `;
@@ -159,6 +217,8 @@ exports[`Storyshots Help Content faq 1`] = `
      
     <a
       href="http://www.smarterbalanced.org/assessments/testing-technology/"
+      rel="noopener noreferrer"
+      target="_blank"
     >
       computer adaptive testing
     </a>
@@ -179,6 +239,8 @@ exports[`Storyshots Help Content faq 1`] = `
      
     <a
       href="http://sampleitems.smarterbalanced.org/AboutItems"
+      rel="noopener noreferrer"
+      target="_blank"
     >
       Sample Items website
     </a>
@@ -192,10 +254,26 @@ exports[`Storyshots Help Content faq 1`] = `
      
     <a
       href="http://calculator.smarterbalanced.org/"
+      rel="noopener noreferrer"
+      target="_blank"
     >
       Smarter Balanced Calculators: Powered by Desmos
     </a>
   </p>
+  <style
+    jsx={true}
+  >
+    
+    a {
+      color: #007393;
+    }
+    a:hover,
+    a:active {
+      color: #111213;
+      text-decoration: none;
+    }
+  
+  </style>
 </div>
 `;
 
@@ -240,16 +318,22 @@ exports[`Storyshots Help Content targets 1`] = `
       Within each claim area, assessment targets were developed to ensure that item writers and reviewers address the standards, learning progressions, and the Depth of Knowledge levels. The assessment targets connect the content standards to evidence that is required to support the content claims. Additionally, assessment targets are used to guide the development of Digital Library resources and assessment items and tasks.
     </li>
     <li>
-      Links to 
+      Links to
+       
       <a
         href="https://smarterbalanced.org"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         ELA targets
       </a>
-       and
+       
+      and
        
       <a
         href="https://smarterbalanced.org/"
+        rel="noopener noreferrer"
+        target="_blank"
       >
         mathematics targets
       </a>
@@ -257,6 +341,20 @@ exports[`Storyshots Help Content targets 1`] = `
     <li>
       ELA claim/target graphics emailed separately 
     </li>
+    <style
+      jsx={true}
+    >
+      
+    a {
+      color: #007393;
+    }
+    a:hover,
+    a:active {
+      color: #111213;
+      text-decoration: none;
+    }
+  
+    </style>
   </ul>
 </div>
 `;

--- a/src/components/HelpContent/index.tsx
+++ b/src/components/HelpContent/index.tsx
@@ -1,5 +1,16 @@
 import React from 'react';
-
+const linkStyle = (
+  <style jsx>{`
+    a {
+      color: #007393;
+    }
+    a:hover,
+    a:active {
+      color: #111213;
+      text-decoration: none;
+    }
+  `}</style>
+);
 export const HelpClaims: React.SFC = () => (
   <ul>
     <li>
@@ -8,19 +19,28 @@ export const HelpClaims: React.SFC = () => (
     </li>
     <li>
       English language arts/literacy has four{' '}
-      <a href="https://portal.smarterbalanced.org/library/en/claims-for-the-ela-literacy-summative-assessments.pdf">
+      <a
+        href="https://portal.smarterbalanced.org/library/en/claims-for-the-ela-literacy-summative-assessments.pdf"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         content claims
       </a>
       : Reading, Writing, Speaking and Listening, and Research/Inquiry
     </li>
     <li>
       Mathematics has four{' '}
-      <a href="https://portal.smarterbalanced.org/library/en/claims-for-the-mathematics-summative-assessments.pdf">
+      <a
+        href="https://portal.smarterbalanced.org/library/en/claims-for-the-mathematics-summative-assessments.pdf"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         content claims:
       </a>{' '}
       Concepts and Procedures, Problem Solving, Communicating Reasoning, and Modeling and Data
       Analysis
     </li>
+    {linkStyle}
   </ul>
 );
 
@@ -34,10 +54,17 @@ export const HelpTargets: React.SFC = () => (
       Library resources and assessment items and tasks.
     </li>
     <li>
-      Links to <a href="https://smarterbalanced.org">ELA targets</a> and{' '}
-      <a href="https://smarterbalanced.org/">mathematics targets</a>
+      Links to{' '}
+      <a href="https://smarterbalanced.org" target="_blank" rel="noopener noreferrer">
+        ELA targets
+      </a>{' '}
+      and{' '}
+      <a href="https://smarterbalanced.org/" target="_blank" rel="noopener noreferrer">
+        mathematics targets
+      </a>
     </li>
     <li>ELA claim/target graphics emailed separately </li>
+    {linkStyle}
   </ul>
 );
 
@@ -54,11 +81,19 @@ export const HelpContentSpec: React.SFC = () => (
   <ul>
     <li>
       Smarter Balanced has developed content specifications in{' '}
-      <a href="https://portal.smarterbalanced.org/library/en/english-language-artsliteracy-content-specifications.pdf">
+      <a
+        href="https://portal.smarterbalanced.org/library/en/english-language-artsliteracy-content-specifications.pdf"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         English language arts/literacy
       </a>{' '}
       and{' '}
-      <a href="https://portal.smarterbalanced.org/library/en/mathematics-content-specifications.pdf">
+      <a
+        href="https://portal.smarterbalanced.org/library/en/mathematics-content-specifications.pdf"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         mathematics
       </a>{' '}
       to ensure that the assessments cover the range of knowledge and skills in the Common Core
@@ -69,17 +104,26 @@ export const HelpContentSpec: React.SFC = () => (
       Digital Library Resources
       <ul>
         <li>
-          <a href="https://www.smarterbalancedlibrary.org/content/understanding-smarter-balanced-mathematics-content-specifications">
+          <a
+            href="https://www.smarterbalancedlibrary.org/content/understanding-smarter-balanced-mathematics-content-specifications"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Mathematics
           </a>
         </li>
         <li>
-          <a href="https://www.smarterbalancedlibrary.org/content/understanding-smarter-balanced-elaliteracy-content-specifications">
+          <a
+            href="https://www.smarterbalancedlibrary.org/content/understanding-smarter-balanced-elaliteracy-content-specifications"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             English language arts/literacy
           </a>
         </li>
       </ul>
     </li>
+    {linkStyle}
   </ul>
 );
 
@@ -106,17 +150,26 @@ export const HelpAccessibility: React.SFC = () => (
       for any state to create on its own.
     </p>
     <p>
-      <a href="https://portal.smarterbalanced.org/library/en/accessibility-accommodations-fact-sheet.pdf">
+      <a
+        href="https://portal.smarterbalanced.org/library/en/accessibility-accommodations-fact-sheet.pdf"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         Accessibility and Accommodations Fact Sheet
       </a>
     </p>
     <p>
       More information about{' '}
-      <a href="http://www.smarterbalanced.org/assessments/accessibility-and-accommodations/">
+      <a
+        href="http://www.smarterbalanced.org/assessments/accessibility-and-accommodations/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         accessibility and accommodations
       </a>{' '}
       can be found on the Smarter Balanced website.
     </p>
+    {linkStyle}
   </React.Fragment>
 );
 
@@ -153,7 +206,11 @@ export const HelpFaq: React.SFC = () => (
       question correctly, the next question will be harder; if a student answers incorrectly, the
       next question will be easier. This system is called computer adaptive testing, and it is part
       of the summative (end-of-year) assessments. More information about{' '}
-      <a href="http://www.smarterbalanced.org/assessments/testing-technology/">
+      <a
+        href="http://www.smarterbalanced.org/assessments/testing-technology/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
         computer adaptive testing
       </a>{' '}
       can be found on the Smarter Balanced website.
@@ -168,17 +225,25 @@ export const HelpFaq: React.SFC = () => (
     <p>
       There are 12 different technology-enhanced item types used by Smarter Balanced. Definitions of
       each item type and sample of each item type can be found on the{' '}
-      <a href="http://sampleitems.smarterbalanced.org/AboutItems">Sample Items website</a>.
+      <a
+        href="http://sampleitems.smarterbalanced.org/AboutItems"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Sample Items website
+      </a>
+      .
     </p>
     <h3>Can the students use a calculator on the mathematics assessment?</h3>
     <p>
       Smarter Balanced and Desmos are proud to offer calculators that are both free to students and
       include cutting edge accessibility features. Students are allowed to use a calculator on a
       certain percentage of mathematics items, depending on the construct being assessed.{' '}
-      <a href="http://calculator.smarterbalanced.org/">
+      <a href="http://calculator.smarterbalanced.org/" target="_blank" rel="noopener noreferrer">
         Smarter Balanced Calculators: Powered by Desmos
       </a>
     </p>
+    {linkStyle}
   </React.Fragment>
 );
 


### PR DESCRIPTION
# Changes introduced

Links in help page now open to new tabs
Link style now matches footer

## Related issue(s):

- CSE-_user story or bug_
- CSE-_task number_

## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [ ] Added new stories for created/modified components (if applicable)
- [ ] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
