### PR TITLE
Fix/cse 338 download modal fix

### DIFF
--- a/src/components/TargetComponents/mocks/index.ts
+++ b/src/components/TargetComponents/mocks/index.ts
@@ -168,7 +168,8 @@ export const parsedTitleBarDataMock: TitleBarProps = {
     'Students can read closely and analytically to comprehend a range of increasingly complex literary and informational texts.',
   downloadBtnProps: {
     url: 'test/url',
-    filename: 'test-file-name'
+    filename: 'test-file-name',
+    taskNames: ['Task Model 1', 'Task Model 2', 'Task Model 3']
   },
   targetTitle: 'English Language Arts Specification: Grade 6 Claim 1 Target 1',
   targetDesc: 'placeholder'

--- a/src/components/TargetComponents/title.tsx
+++ b/src/components/TargetComponents/title.tsx
@@ -22,12 +22,18 @@ export const parseBreadCrumbData = (claim: IClaim): BreadcrumbsProps => {
     target: claim.target[0].title
   };
 };
+export const parseDownloadBtnProps = (claim: IClaim): DownloadBtnProps => {
+  const tNameArr: string[] = [];
+  claim.target[0].taskModels.forEach(tm => tNameArr.push(tm.taskName));
+  downloadBtnMock.taskNames = tNameArr;
 
+  return downloadBtnMock;
+};
 export const parseTitleBarData = (claim: IClaim): TitleBarProps => {
   return {
     claimTitle: claim.claimNumber,
     claimDesc: claim.description,
-    downloadBtnProps: downloadBtnMock,
+    downloadBtnProps: parseDownloadBtnProps(claim),
     targetTitle: claim.target[0].title,
     targetDesc: claim.target[0].description
   };

--- a/src/components/TitleBar/DownloadBtn.tsx
+++ b/src/components/TitleBar/DownloadBtn.tsx
@@ -63,6 +63,7 @@ export class DownloadBtn extends Component<DownloadBtnProps, DownloadBtnState> {
           a {
             color: ${Colors.sbWhite};
             font-size: 30px;
+            cursor: pointer;
           }
           .download-label {
             font-size: 15px;

--- a/src/components/TitleBar/__snapshots__/TitleBar.storybook.storyshot
+++ b/src/components/TitleBar/__snapshots__/TitleBar.storybook.storyshot
@@ -81,6 +81,7 @@ exports[`Storyshots TitleBar component Renders a Title Bar with a claim only 1`]
           a {
             color: #ffffff;
             font-size: 30px;
+            cursor: pointer;
           }
           .download-label {
             font-size: 15px;
@@ -261,6 +262,7 @@ exports[`Storyshots TitleBar component Renders a Title Bar with all data 1`] = `
           a {
             color: #ffffff;
             font-size: 30px;
+            cursor: pointer;
           }
           .download-label {
             font-size: 15px;
@@ -496,6 +498,7 @@ exports[`Storyshots TitleBar component Renders a download button 1`] = `
           a {
             color: #ffffff;
             font-size: 30px;
+            cursor: pointer;
           }
           .download-label {
             font-size: 15px;


### PR DESCRIPTION
# Changes introduced
Fixes missing task models in download modal task selection pane.
Fixes cursor pointer missing on download button.

## Related issue(s):

- CSE-339
## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [ ] Added new stories for created/modified components (if applicable)
- [ ] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
