### PR TITLE
fix(lists): removes unused jsx styling tags

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
     "@babel/proposal-object-rest-spread",
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-transform-runtime",
-    ["styled-jsx/babel", {"optimizeforspeed": false}]
+    "styled-jsx/babel"
   ],
   "env": {
     "test": {

--- a/src/components/TargetComponents/Lists.tsx
+++ b/src/components/TargetComponents/Lists.tsx
@@ -7,27 +7,11 @@ export interface ListProps {
 export const OrderedList: React.SFC<ListProps> = ({ elements }) => {
   const elementsJsx = elements.map((e, i) => <li key={i}>{e}</li>);
 
-  return (
-    <ol>
-      {elementsJsx}
-      <style jsx>{`
-        ol {
-        }
-      `}</style>
-    </ol>
-  );
+  return <ol>{elementsJsx}</ol>;
 };
 
 export const UnorderedList: React.SFC<ListProps> = ({ elements }) => {
   const elementsJsx = elements.map((e, i) => <li key={i}>{e}</li>);
 
-  return (
-    <ul>
-      {elementsJsx}
-      <style jsx>{`
-        ul {
-        }
-      `}</style>
-    </ul>
-  );
+  return <ul>{elementsJsx}</ul>;
 };


### PR DESCRIPTION
# Changes introduced
Removes unused jsx styling from lists.tsx

## Related issue(s):


## Contributor checklist

- [ ] Wrote/updated tests for introduced changes
- [ ] Added new stories for created/modified components (if applicable)
- [ ] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
