### PR TITLE
Feat/cse 373 mobile breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.storybook.storyshot
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.storybook.storyshot
@@ -131,50 +131,6 @@ exports[`Storyshots Breadcrumbs component Renders Breadcrumbs with all data 1`] 
     
           </style>
         </li>
-        <li>
-          <a
-            href="/search?claim=Claim%204&grades=8&subject=ELA"
-            onClick={[Function]}
-            style={
-              Object {
-                "color": "white",
-                "paddingLeft": "20px",
-                "textDecoration": "none",
-              }
-            }
-          >
-            <span
-              aria-label="Claim"
-            >
-              Claim 4
-            </span>
-          </a>
-          <style
-            jsx={true}
-          >
-            
-      * {
-        margin: 0;
-        padding: 0;
-      }
-      li {
-        display: flex;
-        align-items: center;
-        height: 35px;
-        overflow: hidden;
-      }
-      li:before {
-        content: '';
-        height: 32px;
-        width: 32px;
-        right: 20px;
-        border-top: 1px solid #66a1c1;
-        border-right: 1px solid #66a1c1;
-        transform: rotate(45deg);
-      }
-    
-          </style>
-        </li>
       </ul>
     </div>
     <style

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -7,6 +7,8 @@ import { Styles, Colors } from '../../constants/style';
 import { CSEFilterParams, CSESearchQuery } from '../../models/filter';
 import { stringify } from 'query-string';
 import { SearchBaseModel } from '@osu-cass/sb-components';
+import { DesktopBreakSize } from '../MediaQuery/MediaQueryWrapper';
+import MediaQuery from 'react-responsive';
 
 /**
  * Properties for Breadcrumbs
@@ -83,18 +85,20 @@ export const Breadcrumbs = ({ subject, grades, claim, target, targetList }: Brea
               label="Grade"
             />
           )}
-          {subject && grades && claim && (
-            <BreadcrumbLink
-              link={buildSearchUrl(subject, grades, claim)}
-              value={claim}
-              label="Claim"
-            />
-          )}
-          {subject && grades && claim && target && currentTarget && (
-            <div>
-              <BreadcrumbDropDown currentTarget={currentTarget} targets={targetList} />
-            </div>
-          )}
+          <MediaQuery {...DesktopBreakSize}>
+            {subject && grades && claim && (
+              <BreadcrumbLink
+                link={buildSearchUrl(subject, grades, claim)}
+                value={claim}
+                label="Claim"
+              />
+            )}
+            {subject && grades && claim && target && currentTarget && (
+              <div>
+                <BreadcrumbDropDown currentTarget={currentTarget} targets={targetList} />
+              </div>
+            )}
+          </MediaQuery>
         </ul>
       </div>
       <style jsx>{`

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -29,7 +29,7 @@ export interface BreadcrumbsProps {
  * @param grade
  * @param claim
  */
-function buildSearchUrl(subject?: string, grades?: string[], claim?: string): string {
+export function buildSearchUrl(subject?: string, grades?: string[], claim?: string): string {
   const filterParams: CSEFilterParams = {
     subject,
     claim,

--- a/src/components/TargetComponents/mocks/index.ts
+++ b/src/components/TargetComponents/mocks/index.ts
@@ -185,6 +185,7 @@ export const parsedCLaimTargetdataMock: TargetClaimProps = {
 };
 export const parsedMobileTitleBarDataMock: MobileTitleBarProps = {
   claimTitle: 'Claim 1',
+  claimUrl: '/search?claim=C1&grades=6&subject=English%20Language%20Arts',
   targetTitle: 'Target 1',
   downloadBtnProps: {
     claim: ELAG3ClaimMock

--- a/src/components/TargetComponents/title.tsx
+++ b/src/components/TargetComponents/title.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { IClaim } from '../../models/claim';
-import { BreadcrumbsProps, Breadcrumbs } from '../../components/Breadcrumbs';
+import { BreadcrumbsProps, Breadcrumbs, buildSearchUrl } from '../../components/Breadcrumbs';
 import { TitleBarProps, TitleBar, TitleBarWrapped } from '../../components/TitleBar';
-import { MobileTitleBarWrapped } from '../../components/TitleBar/mobileTitleBar';
+import {
+  MobileTitleBarWrapped,
+  MobileTitleBarProps
+} from '../../components/TitleBar/mobileTitleBar';
 import { DownloadBtnProps } from '../../components/TitleBar/DownloadBtn';
 import { blueGradient } from '../../constants/style';
 
@@ -15,13 +18,15 @@ export interface TargetTitleBarProps {
   targetList?: SearchBaseModel[];
 }
 
-export const parseTitleBarMobileData = (claim: IClaim): TitleBarProps => {
+export const parseTitleBarMobileData = (claim: IClaim): MobileTitleBarProps => {
   const codeSegments: string[] = claim.target[0].shortCode.split('.');
   const targetTitle: string = `Target ${codeSegments[codeSegments.length - 1].slice(1)}`;
   const claimTitle: string = `Claim ${claim.claimNumber.slice(1)}`;
+  const claimUrl: string = buildSearchUrl(claim.subject, claim.grades, claim.claimNumber);
 
   return {
     claimTitle,
+    claimUrl,
     targetTitle,
     downloadBtnProps: { claim }
   };

--- a/src/components/TitleBar/__snapshots__/mobileTitleBar.storybook.storyshot
+++ b/src/components/TitleBar/__snapshots__/mobileTitleBar.storybook.storyshot
@@ -16,9 +16,11 @@ exports[`Storyshots Mobile TitleBar component Renders a Title Bar with a claim o
         <li
           className="title"
         >
-          <span>
-            Claim 1
-          </span>
+          <a>
+            <span>
+              Claim 1
+            </span>
+          </a>
         </li>
         <li
           className="download"
@@ -99,33 +101,36 @@ exports[`Storyshots Mobile TitleBar component Renders a Title Bar with a claim o
         display: flex;
         font-family: PT Sans Caption;
         padding: 0.7em 0;
-        backgroundImage: linear-gradient(90deg, #006298, #0085AD)
-        width: '100%',
-        flexBasis: '100%'
+        backgroundimage: linear-gradient(90deg, #006298, #0085AD);
+        width: '100%';
+        flex-basis: '100%';
         flex-direction: row;
         justify-content: center;
-        align-items:center;
+        align-items: center;
       }
 
+      a {
+        color: #ffffff;
+      }
       ul {
         display: flex;
         flex-wrap: wrap;
-        flex-direction:row;
+        flex-direction: row;
         align-items: center;
-        justify-content:space-evenly;
+        justify-content: space-evenly;
         list-style-type: none;
         max-width: 85%;
-        width:100vw;
+        width: 100vw;
         margin: 0;
         padding: 0;
-        }
+      }
       .title {
         color: white;
         font-size: 1.129em;
         text-align: left;
       }
       .download {
-        width:auto;
+        width: auto;
       }
     
       </style>
@@ -150,9 +155,11 @@ exports[`Storyshots Mobile TitleBar component Renders a Title Bar with all data 
         <li
           className="title"
         >
-          <span>
-            Claim 1
-          </span>
+          <a>
+            <span>
+              Claim 1
+            </span>
+          </a>
         </li>
         <li
           className="title"
@@ -240,33 +247,36 @@ exports[`Storyshots Mobile TitleBar component Renders a Title Bar with all data 
         display: flex;
         font-family: PT Sans Caption;
         padding: 0.7em 0;
-        backgroundImage: linear-gradient(90deg, #006298, #0085AD)
-        width: '100%',
-        flexBasis: '100%'
+        backgroundimage: linear-gradient(90deg, #006298, #0085AD);
+        width: '100%';
+        flex-basis: '100%';
         flex-direction: row;
         justify-content: center;
-        align-items:center;
+        align-items: center;
       }
 
+      a {
+        color: #ffffff;
+      }
       ul {
         display: flex;
         flex-wrap: wrap;
-        flex-direction:row;
+        flex-direction: row;
         align-items: center;
-        justify-content:space-evenly;
+        justify-content: space-evenly;
         list-style-type: none;
         max-width: 85%;
-        width:100vw;
+        width: 100vw;
         margin: 0;
         padding: 0;
-        }
+      }
       .title {
         color: white;
         font-size: 1.129em;
         text-align: left;
       }
       .download {
-        width:auto;
+        width: auto;
       }
     
       </style>
@@ -291,9 +301,11 @@ exports[`Storyshots Mobile TitleBar component Renders a Title Bar with header on
         <li
           className="title"
         >
-          <span>
-            Claim 1
-          </span>
+          <a>
+            <span>
+              Claim 1
+            </span>
+          </a>
         </li>
       </ul>
       <style
@@ -304,33 +316,36 @@ exports[`Storyshots Mobile TitleBar component Renders a Title Bar with header on
         display: flex;
         font-family: PT Sans Caption;
         padding: 0.7em 0;
-        backgroundImage: linear-gradient(90deg, #006298, #0085AD)
-        width: '100%',
-        flexBasis: '100%'
+        backgroundimage: linear-gradient(90deg, #006298, #0085AD);
+        width: '100%';
+        flex-basis: '100%';
         flex-direction: row;
         justify-content: center;
-        align-items:center;
+        align-items: center;
       }
 
+      a {
+        color: #ffffff;
+      }
       ul {
         display: flex;
         flex-wrap: wrap;
-        flex-direction:row;
+        flex-direction: row;
         align-items: center;
-        justify-content:space-evenly;
+        justify-content: space-evenly;
         list-style-type: none;
         max-width: 85%;
-        width:100vw;
+        width: 100vw;
         margin: 0;
         padding: 0;
-        }
+      }
       .title {
         color: white;
         font-size: 1.129em;
         text-align: left;
       }
       .download {
-        width:auto;
+        width: auto;
       }
     
       </style>

--- a/src/components/TitleBar/mobileTitleBar.tsx
+++ b/src/components/TitleBar/mobileTitleBar.tsx
@@ -11,6 +11,7 @@ import { MobileBreakSize, mediaQueryWrapper } from '../MediaQuery/MediaQueryWrap
  */
 export interface MobileTitleBarProps {
   claimTitle?: string;
+  claimUrl?: string;
   targetTitle?: string;
   downloadBtnProps?: DownloadBtnProps;
 }
@@ -26,6 +27,7 @@ export interface MobileTitleBarProps {
  */
 export const TitleBar: React.SFC<MobileTitleBarProps> = ({
   claimTitle,
+  claimUrl,
   targetTitle,
   downloadBtnProps
 }: MobileTitleBarProps) => (
@@ -33,7 +35,9 @@ export const TitleBar: React.SFC<MobileTitleBarProps> = ({
     <ul>
       {claimTitle && (
         <li className="title">
-          <span>{claimTitle}</span>
+          <a href={claimUrl}>
+            <span>{claimTitle}</span>
+          </a>
         </li>
       )}
       {targetTitle && (
@@ -52,33 +56,36 @@ export const TitleBar: React.SFC<MobileTitleBarProps> = ({
         display: flex;
         font-family: ${Styles.sbSans};
         padding: 0.7em 0;
-        backgroundImage: linear-gradient(90deg, ${Colors.sbBlue}, ${Colors.sbBlueLighter})
-        width: '100%',
-        flexBasis: '100%'
+        backgroundimage: linear-gradient(90deg, ${Colors.sbBlue}, ${Colors.sbBlueLighter});
+        width: '100%';
+        flex-basis: '100%';
         flex-direction: row;
         justify-content: center;
-        align-items:center;
+        align-items: center;
       }
 
+      a {
+        color: ${Colors.sbWhite};
+      }
       ul {
         display: flex;
         flex-wrap: wrap;
-        flex-direction:row;
+        flex-direction: row;
         align-items: center;
-        justify-content:space-evenly;
+        justify-content: space-evenly;
         list-style-type: none;
         max-width: ${Styles.targetContentWidth};
-        width:100vw;
+        width: 100vw;
         margin: 0;
         padding: 0;
-        }
+      }
       .title {
         color: white;
         font-size: 1.129em;
         text-align: left;
       }
       .download {
-        width:auto;
+        width: auto;
       }
     `}</style>
   </div>


### PR DESCRIPTION
# Changes introduced

This PR makes some tweaks to the Breadcrumbs component, hiding the Claim and Target on mobile devices. It also adds a link to the Claim number in the Mobile title bar, to replace lost functionality.

## Related issue(s):

- CSE-373

## Contributor checklist

- [ ] Wrote/updated tests for introduced changes
- [ ] Added new stories for created/modified components (if applicable)
- [ ] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [ ] Verified that there are no issues in CircleCI
- [ ] Assigned yourself to the PR
- [ ] Removed `WIP:` from the PR title
- [ ] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
