### PR TITLE
CSE-367 Explore options should not display search results until a filter option is selected

### DIFF
--- a/src/clients/filter/index.ts
+++ b/src/clients/filter/index.ts
@@ -1,5 +1,6 @@
-import { SearchBaseModel, FilterType } from '@osu-cass/sb-components';
-import { CSEFilterParams, CSEFilterOptions } from '../../models/filter';
+import { FilterType, SearchBaseModel } from '@osu-cass/sb-components';
+import { CSEFilterOptions, CSEFilterParams } from '../../models/filter';
+
 const { API_ENDPOINT } = process.env;
 
 export interface FilterOptionsTargets {

--- a/src/components/DesktopFilter/__snapshots__/Filter.storybook.storyshot
+++ b/src/components/DesktopFilter/__snapshots__/Filter.storybook.storyshot
@@ -530,7 +530,7 @@ exports[`Storyshots Desktop Filter Subject, Grade and Claim 1`] = `
         <div
           className="message"
         >
-          Please select a Claim.
+          Select a Grade, Subject, and Claim first
           <style
             jsx={true}
           >
@@ -732,7 +732,7 @@ exports[`Storyshots Desktop Filter default 1`] = `
         <div
           className="message"
         >
-          Please select a Grade and Subject
+          Select a Grade and Subject first.
           <style
             jsx={true}
           >

--- a/src/components/DesktopFilter/index.tsx
+++ b/src/components/DesktopFilter/index.tsx
@@ -1,18 +1,6 @@
 import React, { Fragment } from 'react';
-import {
-  AdvancedFilterCategoryModel,
-  AdvancedFilter,
-  FilterOptionModel,
-  FilterType
-} from '@osu-cass/sb-components';
-import {
-  createFilters,
-  sanitizeParams,
-  paramsFromFilter,
-  paramsFromMobileFilter
-} from '../FilterHelper';
-import { CSEFilterOptions, CSEFilterParams } from '../../models/filter';
-import { Colors, blueGradient, Styles, SizeBreaks, mediaQueries } from '../../constants/style';
+import { AdvancedFilter, FilterOptionModel } from '@osu-cass/sb-components';
+import { Colors, blueGradient, Styles } from '../../constants/style';
 import { Message } from '../Message';
 import { FilterProps, CSEAdvancedFilterModels } from '../FilterProps';
 import css from 'styled-jsx/css';

--- a/src/components/DesktopFilter/index.tsx
+++ b/src/components/DesktopFilter/index.tsx
@@ -1,10 +1,10 @@
-import React, { Fragment } from 'react';
 import { AdvancedFilter, FilterOptionModel } from '@osu-cass/sb-components';
-import { Colors, blueGradient, Styles } from '../../constants/style';
-import { Message } from '../Message';
-import { FilterProps, CSEAdvancedFilterModels } from '../FilterProps';
+import React, { Fragment } from 'react';
 import css from 'styled-jsx/css';
-import { mediaQueryWrapper, DesktopBreakSize } from '../MediaQuery/MediaQueryWrapper';
+import { blueGradient, Colors, Styles } from '../../constants/style';
+import { CSEAdvancedFilterModels, FilterProps } from '../FilterProps';
+import { DesktopBreakSize, mediaQueryWrapper } from '../MediaQuery/MediaQueryWrapper';
+import { Message } from '../Message';
 
 export const globalFilterStyle = css`
   .filter-selection {

--- a/src/components/DesktopFilter/index.tsx
+++ b/src/components/DesktopFilter/index.tsx
@@ -87,7 +87,7 @@ export const DesktopFilter: React.SFC<FilterProps> = ({ filters, onUpdate, reset
         />
       );
     } else {
-      content = <Message>Please select a Grade and Subject</Message>;
+      content = <Message>Select a Grade and Subject first.</Message>;
     }
 
     return content;
@@ -106,7 +106,7 @@ export const DesktopFilter: React.SFC<FilterProps> = ({ filters, onUpdate, reset
         />
       );
     } else if (claimFilter) {
-      content = <Message>Please select a Claim.</Message>;
+      content = <Message>Select a Grade, Subject, and Claim first</Message>;
     }
 
     return content;

--- a/src/components/FilterComponent/index.tsx
+++ b/src/components/FilterComponent/index.tsx
@@ -1,18 +1,18 @@
-import React, { Fragment } from 'react';
-import { FilterProps, CSEAdvancedFilterModels, FilterComponentProps } from '../FilterProps';
-import {
-  sanitizeParams,
-  createFilters,
-  paramsFromFilter,
-  paramsFromMobileFilter
-} from '../FilterHelper';
-import { sortHelper } from './sortHelper';
 import { FilterOptionModel, FilterType } from '@osu-cass/sb-components';
-import { MobileFilter, MobileFilterWrapped } from '../MobileFilter';
-import { ToggleBtn, ToggleBtnProps } from '../ToggleBtn';
+import React, { Fragment } from 'react';
+import { performanceOptions } from '../../models/filter';
 import { DesktopFilterWrapped } from '../DesktopFilter';
 import { FilterContainer } from '../FilterContainer';
-import { performanceOptions } from '../../models/filter';
+import {
+  createFilters,
+  paramsFromFilter,
+  paramsFromMobileFilter,
+  sanitizeParams
+} from '../FilterHelper';
+import { CSEAdvancedFilterModels, FilterComponentProps } from '../FilterProps';
+import { MobileFilterWrapped } from '../MobileFilter';
+import { ToggleBtn, ToggleBtnProps } from '../ToggleBtn';
+import { sortHelper } from './sortHelper';
 
 export const FilterComponent: React.SFC<FilterComponentProps> = ({
   options,

--- a/src/components/FilterContainer/index.storybook.tsx
+++ b/src/components/FilterContainer/index.storybook.tsx
@@ -5,5 +5,5 @@ import { FilterContainer } from '.';
 
 storiesOf('FilterContianer', module)
   .addDecorator(centered)
-  .add('default', () => <FilterContainer>Filter goes here</FilterContainer>)
+  .add('default', () => <FilterContainer expanded={false}>Filter goes here</FilterContainer>)
   .add('expanded', () => <FilterContainer expanded>Filter goes here</FilterContainer>);

--- a/src/components/FilterContainer/index.tsx
+++ b/src/components/FilterContainer/index.tsx
@@ -3,7 +3,7 @@ import { ChevronDown, ChevronUp, Filter } from 'react-feather';
 import { Colors, Styles } from '../../constants/style';
 
 export interface FilterContainerProps {
-  expanded?: boolean;
+  expanded: boolean;
 }
 
 export interface FilterContainerState {
@@ -22,8 +22,15 @@ export class FilterContainer extends React.Component<FilterContainerProps, Filte
     super(props);
 
     this.state = {
-      expanded: props.expanded || false
+      expanded: props.expanded
     };
+  }
+
+  componentDidUpdate(prevProps: FilterContainerProps) {
+    const { expanded } = this.props;
+    if (prevProps.expanded !== expanded) {
+      this.setState({ expanded });
+    }
   }
 
   toggleExpanded = () => {

--- a/src/components/FilterProps/index.ts
+++ b/src/components/FilterProps/index.ts
@@ -9,7 +9,7 @@ export interface FilterComponentProps {
   options: CSEFilterOptions;
   params: CSEFilterParams;
   onUpdate: (filter: CSEFilterParams) => void;
-  expanded?: boolean;
+  expanded: boolean;
   filterPT?: () => void;
 }
 

--- a/src/components/SearchPage/index.tsx
+++ b/src/components/SearchPage/index.tsx
@@ -27,8 +27,8 @@ export interface SearchPageState {
   pt: boolean;
 }
 
-function anyParams(urlParmas: CSESearchQuery): boolean {
-  return Object.values(urlParmas).some((p: boolean) => p);
+function anyParams(urlParams: CSESearchQuery): boolean {
+  return urlParams.filter ? true : false;
 }
 
 function unwrapError<T>(data?: T | Error): T | undefined {
@@ -71,7 +71,8 @@ export class SearchPage extends React.Component<SearchPageProps, SearchPageState
         grades: props.paramsFromUrl.grades || [],
         subject: props.paramsFromUrl.subject,
         claim: props.paramsFromUrl.claim,
-        target: props.paramsFromUrl.target
+        target: props.paramsFromUrl.target,
+        filter: props.paramsFromUrl.filter
       },
       search: props.paramsFromUrl.search || '',
       pt: false
@@ -79,7 +80,8 @@ export class SearchPage extends React.Component<SearchPageProps, SearchPageState
   }
 
   async componentDidMount() {
-    const options = await this.props.filterClient.getFilterOptions(this.state.params);
+    const { filter, ...filterParams } = this.state.params;
+    const options = await this.props.filterClient.getFilterOptions(filterParams);
     this.setState({ options });
   }
 

--- a/src/components/SearchPage/index.tsx
+++ b/src/components/SearchPage/index.tsx
@@ -4,12 +4,7 @@ import { FilterItemList } from '../FilterItemList';
 import { CSEFilterOptions, CSEFilterParams, CSESearchQuery } from '../../models/filter';
 import { Styles } from '../../constants/style';
 import { Message, ErrorMessage } from '../Message';
-import {
-  FilterType,
-  ErrorBoundary,
-  FilterOptionModel,
-  AdvancedFilter
-} from '@osu-cass/sb-components';
+import { FilterType, ErrorBoundary } from '@osu-cass/sb-components';
 import { ISearchClient } from '../../clients/search';
 import { IClaim } from '../../models/claim';
 import { IFilterClient } from '../../clients/filter';
@@ -84,16 +79,8 @@ export class SearchPage extends React.Component<SearchPageProps, SearchPageState
   }
 
   async componentDidMount() {
-    if (anyParams(this.props.paramsFromUrl)) {
-      const [results, options] = await Promise.all([
-        this.props.searchClient.search(this.props.paramsFromUrl),
-        this.props.filterClient.getFilterOptions(this.state.params)
-      ]);
-      this.setState({ results, options });
-    } else {
-      const options = await this.props.filterClient.getFilterOptions(this.state.params);
-      this.setState({ options });
-    }
+    const options = await this.props.filterClient.getFilterOptions(this.state.params);
+    this.setState({ options });
   }
 
   private updateQuery(search: string, params: CSEFilterParams) {

--- a/src/models/filter/index.ts
+++ b/src/models/filter/index.ts
@@ -15,6 +15,7 @@ export interface CSEFilterParams {
   subject?: string;
   claim?: string;
   target?: string;
+  filter?: string;
 }
 
 export interface CSESearchQuery {
@@ -23,4 +24,5 @@ export interface CSESearchQuery {
   claim?: string;
   target?: string;
   search?: string;
+  filter?: string;
 }

--- a/src/pages/Target/index.tsx
+++ b/src/pages/Target/index.tsx
@@ -1,15 +1,15 @@
+import { SearchBaseModel } from '@osu-cass/sb-components';
 import React from 'react';
 import { RouteComponentProps } from 'react-router';
-import { IClaim } from '../../models/claim';
-import { ITargetClient, TargetClient } from '../../clients/target';
-import { genericLayout } from '../../components/GenericPage/GenericLayout';
-import { TargetTitleBar } from '../../components/TargetComponents/title';
-import { ClaimTarget } from '../../components/TargetComponents/ClaimTarget';
-import { Message, ErrorMessage } from '../../components/Message';
-import { TargetDetail } from '../../components/TargetComponents/TargetDetail';
 import { FilterClient } from '../../clients/filter';
-import { CSEFilterParams, CSEFilterOptions } from '../../models/filter';
-import { SearchBaseModel } from '@osu-cass/sb-components';
+import { TargetClient } from '../../clients/target';
+import { genericLayout } from '../../components/GenericPage/GenericLayout';
+import { ErrorMessage, Message } from '../../components/Message';
+import { ClaimTarget } from '../../components/TargetComponents/ClaimTarget';
+import { TargetDetail } from '../../components/TargetComponents/TargetDetail';
+import { TargetTitleBar } from '../../components/TargetComponents/title';
+import { IClaim } from '../../models/claim';
+import { CSEFilterOptions, CSEFilterParams } from '../../models/filter';
 
 export interface TargetMatchParams {
   targetShortCode?: string;


### PR DESCRIPTION
# Changes introduced

- I stopped search results from loading when navigating to the Explore page
- Update user prompts in the filter (CSE-336)
- Search and Explore render with filter closed and open respectively 

## Related issue(s):

- CSE-367
- CSE-336

## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [x] Added new stories for created/modified components (if applicable)
- [x] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
