### PR TITLE
Fix Help digital library links

### DIFF
--- a/src/components/HelpContent/__snapshots__/index.storybook.storyshot
+++ b/src/components/HelpContent/__snapshots__/index.storybook.storyshot
@@ -148,7 +148,7 @@ exports[`Storyshots Help Content content spec 1`] = `
       <ul>
         <li>
           <a
-            href="https://www.smarterbalancedlibrary.org/content/understanding-smarter-balanced-mathematics-content-specifications"
+            href="https://www.smarterbalancedlibrary.org/sbac-share?key=27eebc6f15044787d9a1171ebee1de26"
             rel="noopener noreferrer"
             target="_blank"
           >
@@ -157,7 +157,7 @@ exports[`Storyshots Help Content content spec 1`] = `
         </li>
         <li>
           <a
-            href="https://www.smarterbalancedlibrary.org/content/understanding-smarter-balanced-elaliteracy-content-specifications"
+            href="https://www.smarterbalancedlibrary.org/sbac-share?key=7d5c0d0d92128e7b80be654209f31451"
             rel="noopener noreferrer"
             target="_blank"
           >

--- a/src/components/HelpContent/index.tsx
+++ b/src/components/HelpContent/index.tsx
@@ -105,7 +105,7 @@ export const HelpContentSpec: React.SFC = () => (
       <ul>
         <li>
           <a
-            href="https://www.smarterbalancedlibrary.org/content/understanding-smarter-balanced-mathematics-content-specifications"
+            href="https://www.smarterbalancedlibrary.org/sbac-share?key=27eebc6f15044787d9a1171ebee1de26"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -114,7 +114,7 @@ export const HelpContentSpec: React.SFC = () => (
         </li>
         <li>
           <a
-            href="https://www.smarterbalancedlibrary.org/content/understanding-smarter-balanced-elaliteracy-content-specifications"
+            href="https://www.smarterbalancedlibrary.org/sbac-share?key=7d5c0d0d92128e7b80be654209f31451"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
# Changes introduced

This PR updates the links under Help > Content Specifications > Digital Library Resources to use the URLs specified in CSE-383.

## Related issue(s):

- CSE-383

## Contributor checklist

- [ ] Wrote/updated tests for introduced changes
- [ ] Added new stories for created/modified components (if applicable)
- [ ] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
