### PR TITLE
Fix Resources alignment

### DIFF
--- a/src/pages/Resources/__snapshots__/ResourcesPage.storybook.storyshot
+++ b/src/pages/Resources/__snapshots__/ResourcesPage.storybook.storyshot
@@ -640,21 +640,12 @@ exports[`Storyshots Resources Page Render the Resources page 1`] = `
     
               </style>
             </div>
-            <div
-              className="resource-page-mobile-padding"
-            />
           </div>
         </div>
         <style
           jsx={true}
         >
           
-      @media (max-width: 500px) {
-        .resource-page-mobile-padding {
-          height: 200px;
-          width: 100px;
-        }
-      }
       .content {
         display: flex;
         flex-direction: column;

--- a/src/pages/Resources/index.tsx
+++ b/src/pages/Resources/index.tsx
@@ -60,16 +60,9 @@ const ResourcesPageComponent: React.SFC = () => (
         {linkProps.map((props: ResourceLinkProps, idx: number) => (
           <ResourceLink key={idx} {...props} />
         ))}
-        <div className="resource-page-mobile-padding" />
       </div>
     </div>
     <style jsx>{`
-      @media (max-width: ${MobileBreakSize.maxWidth}px) {
-        .resource-page-mobile-padding {
-          height: 200px;
-          width: 100px;
-        }
-      }
       .content {
         display: flex;
         flex-direction: column;

--- a/src/pages/Resources/index.tsx
+++ b/src/pages/Resources/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { genericLayout } from '../../components/GenericPage/GenericLayout';
 import { ResourceLinkProps, ResourceLink } from '../../components/ResourceLink';
 import { Title } from '../../components/GenericPage/Title';
-import { MobileBreakSize } from '../../components/MediaQuery/MediaQueryWrapper';
 
 /*tslint:disable: no-require-imports no-var-requires */
 const scoreimg: string = require('../../assets/images/score-guide.png') as string;


### PR DESCRIPTION
# Changes introduced

A rogue mobile padding element was causing the Sample Items Website resource to become misaligned with the rest of the resources. It appeared to cause positioning issues even in the mobile version, so I removed the element entirely. The formatting is fixed now.

## Related issue(s):

- CSE-382

## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [ ] Added new stories for created/modified components (if applicable)
- [ ] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
