### PR TITLE
fix(parse-utils): adds handling for parsing example arrays

### DIFF
--- a/src/components/TargetDetails/TargetTitleBar/parseUtils.spec.tsx
+++ b/src/components/TargetDetails/TargetTitleBar/parseUtils.spec.tsx
@@ -1,0 +1,24 @@
+import { parseExamples } from '../parseUtils';
+
+const mockExamples = [
+  'Primary Target 2A (Content Domain NBT), Secondary Target 1E (CCSS 3.NBT.A), Tertiary Target 2C',
+  'Example Item 2A.2a (Grade 3)',
+  'Examples',
+  'Sabina has a jar full of dimes. A pack of cards costs 76 cents. How many dimes would she need to buy the cards if she uses no other coins?\r\n\r\nEnter your answer in the response box.',
+  '(1 point) The student enters the correct number of dimes (8).',
+  'This item requires the student to interpret the value of a collection of dimes as a multiple of ten, and so draws on the skill set identified in Claim 2C.',
+  'NA'
+];
+
+describe('ParseUtils', () => {
+  it('handles string vs string array parsing', () => {
+    const array = parseExamples(mockExamples);
+    const single = parseExamples(
+      'Sabina has a jar full of dimes. A pack of cards costs 76 cents. How many dimes would she need to buy the cards if she uses no other coins?\r\n\r\nEnter your answer in the response box.'
+    );
+    if (array && single) {
+      expect(array.length).toBe(9);
+      expect(single.length).toBe(3);
+    }
+  });
+});

--- a/src/components/TargetDetails/TargetTitleBar/parseUtils.spec.tsx
+++ b/src/components/TargetDetails/TargetTitleBar/parseUtils.spec.tsx
@@ -20,5 +20,6 @@ describe('ParseUtils', () => {
       expect(array.length).toBe(9);
       expect(single.length).toBe(3);
     }
+    expect(parseExamples('')).toBe(undefined);
   });
 });

--- a/src/components/TargetDetails/parseUtils.tsx
+++ b/src/components/TargetDetails/parseUtils.tsx
@@ -122,7 +122,7 @@ export const parseExamples = (example: string | string[]) => {
   let lines: string[] | undefined = [];
   if (typeof example === 'string') {
     lines = splitByNewLine(example);
-  } else {
+  } else if (Array.isArray(example)) {
     example.forEach(e => {
       const splits = splitByNewLine(e);
       if (splits && lines) {

--- a/src/components/TargetDetails/parseUtils.tsx
+++ b/src/components/TargetDetails/parseUtils.tsx
@@ -29,7 +29,7 @@ const replaceCharRef = (text: string) => text.replace(/&#(\d*)/g, replacer);
 
 function replaceFractions(text: string): string {
   let newContent = text;
-  const fractionPattern = /\$\\frac{(\w+)}{(\w+)}\$/g;
+  const fractionPattern = /\$.*\\frac{(\w+)}{(\w+)}\$/g;
   const match = text.match(fractionPattern);
 
   if (match) {
@@ -89,7 +89,7 @@ const parseDoubleAsterisks = (text: string, underlined: boolean) => {
 // I'm assuming you've already checked if this line of the
 // content is an image prior to this function call
 export const parseImageTags = (text: string): JSX.Element => {
-  const urlPattern = /\!\[\]\((.*)\)/;
+  const urlPattern = /\!\[.*\]\((.*)\)/;
   const match = text.match(urlPattern);
   const url = match && match[1];
 
@@ -108,7 +108,7 @@ export const parseContent = (text: string | undefined) => {
 
   return lines.map((line, index) => {
     let content;
-    if (line.startsWith('![](') && line.endsWith(')')) {
+    if (line.startsWith('![') && line.endsWith(')')) {
       content = parseImageTags(line);
     } else {
       content = parseDoubleAsterisks(line, underlined);

--- a/src/components/TargetDetails/parseUtils.tsx
+++ b/src/components/TargetDetails/parseUtils.tsx
@@ -118,13 +118,27 @@ export const parseContent = (text: string | undefined) => {
   });
 };
 
-export const parseExamples = (example: string) => {
-  const lines = splitByNewLine(example);
+export const parseExamples = (example: string | string[]) => {
+  let lines: string[] | undefined = [];
+  if (typeof example === 'object') {
+    example.forEach(e => {
+      const splits = splitByNewLine(e);
+      if (splits) {
+        splits.forEach(s => {
+          if (lines) {
+            lines.push(s);
+          }
+        });
+      }
+    });
+  } else {
+    lines = splitByNewLine(example);
+  }
   let content;
   if (lines) {
     content = lines.map(parseContent);
   } else {
-    content = parseContent(example);
+    content = parseContent(example as string);
   }
 
   return content;

--- a/src/components/TargetDetails/parseUtils.tsx
+++ b/src/components/TargetDetails/parseUtils.tsx
@@ -120,26 +120,16 @@ export const parseContent = (text: string | undefined) => {
 
 export const parseExamples = (example: string | string[]) => {
   let lines: string[] | undefined = [];
-  if (typeof example === 'object') {
+  if (typeof example === 'string') {
+    lines = splitByNewLine(example);
+  } else {
     example.forEach(e => {
       const splits = splitByNewLine(e);
-      if (splits) {
-        splits.forEach(s => {
-          if (lines) {
-            lines.push(s);
-          }
-        });
+      if (splits && lines) {
+        lines = lines.concat(splits);
       }
     });
-  } else {
-    lines = splitByNewLine(example);
-  }
-  let content;
-  if (lines) {
-    content = lines.map(parseContent);
-  } else {
-    content = parseContent(example as string);
   }
 
-  return content;
+  return lines ? lines.map(parseContent) : parseContent(example as string);
 };


### PR DESCRIPTION
# Changes introduced
Changes the parseExamples() logic to handle string arrays.
Fixes a bug that caused Math targets in claims other than claim 1 to not render

## Related issue(s):

- CSE-394

## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [ ] Added new stories for created/modified components (if applicable)
- [ ] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
