### PR TITLE
fix/CSE-393 updates mobile break size to fit phones horizontally

### DIFF
--- a/src/components/GenericPage/__snapshots__/GenericLayout.story.storyshot
+++ b/src/components/GenericPage/__snapshots__/GenericLayout.story.storyshot
@@ -71,7 +71,7 @@ exports[`Storyshots Generic Layout default 1`] = `
           -webkit-overflow-scrolling: touch;
           flex-grow: 1;
         }
-        @media (max-width: 500px) {
+        @media (max-width: 800px) {
           .mobile-padding {
             height: 200px;
             width: 100px;

--- a/src/components/ResourceLink/__snapshots__/ResourceLink.story.storyshot
+++ b/src/components/ResourceLink/__snapshots__/ResourceLink.story.storyshot
@@ -172,7 +172,7 @@ exports[`Storyshots Resource Link Complete example 1`] = `
         font-size: 1em;
         height: 80px;
       }
-      @media (max-width: 500px) {
+      @media (max-width: 800px) {
         .desc {
           height: auto;
         }

--- a/src/components/TitleBar/__snapshots__/TitleBar.story.storyshot
+++ b/src/components/TitleBar/__snapshots__/TitleBar.story.storyshot
@@ -93,7 +93,7 @@ exports[`Storyshots TitleBar component Renders a Title Bar with a claim only 1`]
             flex-direction: column;
             color: White;
           }
-          @media (max-width: 500px) {
+          @media (max-width: 800px) {
             .download-label {
               display: none;
             }
@@ -282,7 +282,7 @@ exports[`Storyshots TitleBar component Renders a Title Bar with all data 1`] = `
             flex-direction: column;
             color: White;
           }
-          @media (max-width: 500px) {
+          @media (max-width: 800px) {
             .download-label {
               display: none;
             }
@@ -526,7 +526,7 @@ exports[`Storyshots TitleBar component Renders a download button 1`] = `
             flex-direction: column;
             color: White;
           }
-          @media (max-width: 500px) {
+          @media (max-width: 800px) {
             .download-label {
               display: none;
             }

--- a/src/components/TitleBar/__snapshots__/mobileTitleBar.story.storyshot
+++ b/src/components/TitleBar/__snapshots__/mobileTitleBar.story.storyshot
@@ -80,7 +80,7 @@ exports[`Storyshots Mobile TitleBar component Renders a Title Bar with a claim o
             flex-direction: column;
             color: White;
           }
-          @media (max-width: 500px) {
+          @media (max-width: 800px) {
             .download-label {
               display: none;
             }
@@ -226,7 +226,7 @@ exports[`Storyshots Mobile TitleBar component Renders a Title Bar with all data 
             flex-direction: column;
             color: White;
           }
-          @media (max-width: 500px) {
+          @media (max-width: 800px) {
             .download-label {
               display: none;
             }
@@ -418,7 +418,7 @@ exports[`Storyshots Mobile TitleBar component Renders a download button 1`] = `
             flex-direction: column;
             color: White;
           }
-          @media (max-width: 500px) {
+          @media (max-width: 800px) {
             .download-label {
               display: none;
             }

--- a/src/constants/style/index.ts
+++ b/src/constants/style/index.ts
@@ -48,7 +48,7 @@ export const mobileIconStyle: IconProps = {
 };
 
 export enum SizeBreaks {
-  mobile = 500,
+  mobile = 800,
   tablet = 950
 }
 

--- a/src/pages/Development/__snapshots__/Development.story.storyshot
+++ b/src/pages/Development/__snapshots__/Development.story.storyshot
@@ -108,7 +108,7 @@ exports[`Storyshots Development Page Default 1`] = `
           -webkit-overflow-scrolling: touch;
           flex-grow: 1;
         }
-        @media (max-width: 500px) {
+        @media (max-width: 800px) {
           .mobile-padding {
             height: 200px;
             width: 100px;

--- a/src/pages/Help/__snapshots__/Help.story.storyshot
+++ b/src/pages/Help/__snapshots__/Help.story.storyshot
@@ -108,7 +108,7 @@ exports[`Storyshots Help Page default 1`] = `
           -webkit-overflow-scrolling: touch;
           flex-grow: 1;
         }
-        @media (max-width: 500px) {
+        @media (max-width: 800px) {
           .mobile-padding {
             height: 200px;
             width: 100px;

--- a/src/pages/Home/__snapshots__/Home.story.storyshot
+++ b/src/pages/Home/__snapshots__/Home.story.storyshot
@@ -198,7 +198,7 @@ exports[`Storyshots HomeContent component HomeContent 1`] = `
         background-repeat: no-repeat;
         height: 100%;
       }
-      @media (max-width: 500px) {
+      @media (max-width: 800px) {
         :global(.home-image){
           background-image: none;
           background-color:white;
@@ -256,7 +256,7 @@ exports[`Storyshots HomeContent component HomeContent 1`] = `
           -webkit-overflow-scrolling: touch;
           flex-grow: 1;
         }
-        @media (max-width: 500px) {
+        @media (max-width: 800px) {
           .mobile-padding {
             height: 200px;
             width: 100px;

--- a/src/pages/Resources/__snapshots__/ResourcesPage.story.storyshot
+++ b/src/pages/Resources/__snapshots__/ResourcesPage.story.storyshot
@@ -206,7 +206,7 @@ exports[`Storyshots Resources Page Render the Resources page 1`] = `
         font-size: 1em;
         height: 80px;
       }
-      @media (max-width: 500px) {
+      @media (max-width: 800px) {
         .desc {
           height: auto;
         }
@@ -348,7 +348,7 @@ exports[`Storyshots Resources Page Render the Resources page 1`] = `
         font-size: 1em;
         height: 80px;
       }
-      @media (max-width: 500px) {
+      @media (max-width: 800px) {
         .desc {
           height: auto;
         }
@@ -490,7 +490,7 @@ exports[`Storyshots Resources Page Render the Resources page 1`] = `
         font-size: 1em;
         height: 80px;
       }
-      @media (max-width: 500px) {
+      @media (max-width: 800px) {
         .desc {
           height: auto;
         }
@@ -632,7 +632,7 @@ exports[`Storyshots Resources Page Render the Resources page 1`] = `
         font-size: 1em;
         height: 80px;
       }
-      @media (max-width: 500px) {
+      @media (max-width: 800px) {
         .desc {
           height: auto;
         }
@@ -701,7 +701,7 @@ exports[`Storyshots Resources Page Render the Resources page 1`] = `
           -webkit-overflow-scrolling: touch;
           flex-grow: 1;
         }
-        @media (max-width: 500px) {
+        @media (max-width: 800px) {
           .mobile-padding {
             height: 200px;
             width: 100px;


### PR DESCRIPTION
# Changes introduced

updates mobile break size too 800px instead of 500px to fit phones that are oriented horizontally.
changes.

## Related issue(s):


## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [ ] Added new stories for created/modified components (if applicable)
- [ ] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
