### PR TITLE
fix/CSE-407-changes color for standards from red to black

### DIFF
--- a/src/components/TargetDetails/Standards/index.tsx
+++ b/src/components/TargetDetails/Standards/index.tsx
@@ -17,31 +17,13 @@ const sortStandards = (a: IStandards, b: IStandards) => {
   return 0;
 };
 
-const colorStandardCode = (code: string) => {
-  const found = code.match('^.*[0-9]$');
-  if (found) {
-    return (
-      <span>
-        {code}
-        <style jsx>{`
-          span {
-            color: #e00;
-          }
-        `}</style>
-      </span>
-    );
-  }
-
-  return code;
-};
-
 export interface StandardsProps {
   standards: IStandards[];
 }
 
 export const Standards: React.SFC<StandardsProps> = ({ standards }) => {
   const standardsJsx = standards.sort(sortStandards).map((standard, index) => {
-    const code = colorStandardCode(shortenStandardCode(standard.stdCode));
+    const code = shortenStandardCode(standard.stdCode);
     const desc = parseContent(standard.stdDesc);
 
     return (


### PR DESCRIPTION
# Changes introduced
 removes colorStandardCode function

## Related issue(s):

- CSE-407
- CSE-_task number_

## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [ ] Added new stories for created/modified components (if applicable)
- [ ] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
