### PR TITLE
fix(download-modal): adds disabling confirm button support

### DIFF
--- a/src/components/DownloadModal/__snapshots__/DownloadModal.spec.tsx.snap
+++ b/src/components/DownloadModal/__snapshots__/DownloadModal.spec.tsx.snap
@@ -189,6 +189,7 @@ exports[`DownloadModal Renders Correctly 1`] = `
           Back
         </button>
         <button
+          disabled={false}
           id="confirm-btn"
           onClick={[Function]}
           type="button"
@@ -210,6 +211,7 @@ exports[`DownloadModal Renders Correctly 1`] = `
             text-align: center;
             text-align: -webkit-center;
             border: solid;
+            cursor: pointer;
             line-height: 30px;
             border-color: #63666A;
             border-radius: 4px;
@@ -252,6 +254,11 @@ exports[`DownloadModal Renders Correctly 1`] = `
             margin-top: 10px;
             display: inline-block;
             color: #ebebeb;
+          }
+          #confirm-back-btn-container button :disabled {
+            background-image: none;
+            background-color: #63666A;
+            cursor: default;
           }
         
       </style>

--- a/src/components/DownloadModal/index.tsx
+++ b/src/components/DownloadModal/index.tsx
@@ -31,6 +31,7 @@ export interface DownloadModalState {
   selectedList: string[];
   submitDownloadProps: DocumentProps;
   submitDownload: boolean;
+  isDisabled: boolean;
 }
 
 const customStyles = {
@@ -56,6 +57,7 @@ export class DownloadModal extends Component<DownloadModalProps, DownloadModalSt
   constructor(props: DownloadModalProps) {
     super(props);
     this.state = {
+      isDisabled: false,
       showModal: props.isOpen,
       showHide: 'hidden',
       showMultiSelect: '',
@@ -87,7 +89,8 @@ export class DownloadModal extends Component<DownloadModalProps, DownloadModalSt
         renderEntireTarget: this.state.selectedList.includes('Entire Target')
       },
       // showModal: false,
-      submitDownload: true
+      submitDownload: true,
+      isDisabled: true
     });
     // if (this.props.closeFromParent !== undefined) {
     //   this.props.closeFromParent();
@@ -127,7 +130,9 @@ export class DownloadModal extends Component<DownloadModalProps, DownloadModalSt
     this.setState({
       showMultiSelect: '',
       showHide: 'hidden',
-      selectedList: []
+      selectedList: [],
+      isDisabled: false,
+      submitDownload: false
     });
   };
 
@@ -367,7 +372,12 @@ export class DownloadModal extends Component<DownloadModalProps, DownloadModalSt
           <button type="button" id="back-btn" onClick={this.handleBackButton}>
             Back
           </button>
-          <button type="button" id="confirm-btn" onClick={this.handleConfirm}>
+          <button
+            type="button"
+            id="confirm-btn"
+            onClick={this.handleConfirm}
+            disabled={this.state.isDisabled}
+          >
             Confirm
           </button>
         </div>
@@ -382,6 +392,7 @@ export class DownloadModal extends Component<DownloadModalProps, DownloadModalSt
             text-align: center;
             text-align: -webkit-center;
             border: solid;
+            cursor: pointer;
             line-height: 30px;
             border-color: ${Colors.sbGray};
             border-radius: 4px;
@@ -424,6 +435,11 @@ export class DownloadModal extends Component<DownloadModalProps, DownloadModalSt
             margin-top: 10px;
             display: inline-block;
             color: ${Colors.sbGrayLighter};
+          }
+          #confirm-back-btn-container button :disabled {
+            background-image: none;
+            background-color: ${Colors.sbGray};
+            cursor: default;
           }
         `}</style>
       </div>


### PR DESCRIPTION
# Changes introduced
Improves user experience when using the download modal.
After clicking confirm, the confirm button is disabled until back is pressed.

## Related issue(s):

- CSE-403


## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [ ] Added new stories for created/modified components (if applicable)
- [ ] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
