### PR TITLE
chore(homepage): updates explore content button text

### DIFF
--- a/src/pages/Home/__snapshots__/Home.story.storyshot
+++ b/src/pages/Home/__snapshots__/Home.story.storyshot
@@ -123,7 +123,7 @@ exports[`Storyshots HomeContent component HomeContent 1`] = `
                     <button
                       className="single-button"
                     >
-                      Navigate to a Target
+                      Explore Content Specifications
                     </button>
                   </a>
                   <a

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -8,7 +8,7 @@ import css from 'styled-jsx/css';
 import { MobileBreakSize } from '../../components/MediaQueryWrapper';
 
 const importedLogo = homeLogo as string;
-const homestyle= css` .content {
+const homestyle = css` .content {
   display: flex;
   flex-direction: row;
   font-family: PT Serif;
@@ -91,8 +91,8 @@ const HomePageComponent = () => (
     <div className="passage">
       <h1 className="passage-title">Welcome!</h1>
       <div className="passage-content">
-        The Content Specification Explorer is a tool for educators to learn about the design and content of
-        the Smarter Balanced assessments. <br />
+        The Content Specification Explorer is a tool for educators to learn about the design and
+        content of the Smarter Balanced assessments. <br />
         <br />
         Choose “Navigate to a Target” to find item specifications, linking the claims and assessment
         targets to the content standards. <br />
@@ -102,16 +102,14 @@ const HomePageComponent = () => (
       </div>
       <div className="buttons">
         <Link to="/explore?filter=open">
-          <button className="single-button">Navigate to a Target</button>
+          <button className="single-button">Explore Content Specifications</button>
         </Link>
         <Link to="/development">
           <button className="single-button">Learn About Test Development</button>
         </Link>
       </div>
     </div>
-    <style jsx>
-    {homestyle}
-    </style>
+    <style jsx>{homestyle}</style>
   </div>
 );
 // cSpell:enable


### PR DESCRIPTION
# Changes introduced
Updates Homepage "Navigate to Target" text to "Explore Content Specifications"

## Related issue(s):

- CSE-418


## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [ ] Added new stories for created/modified components (if applicable)
- [ ] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
