### PR TITLE
Feat/cse 432 breadcrumb links

### DIFF
--- a/src/components/BreadcrumbDropDown/__snapshots__/BreadcrumbDropDown.story.storyshot
+++ b/src/components/BreadcrumbDropDown/__snapshots__/BreadcrumbDropDown.story.storyshot
@@ -23,7 +23,9 @@ exports[`Storyshots Breadcrumbs/Drop Down With targets 1`] = `
       >
         <li
           onClick={[Function]}
+          onKeyPress={[Function]}
           role="Menu"
+          tabIndex={0}
         >
           <div
             className="targetContainer"
@@ -144,7 +146,9 @@ exports[`Storyshots Breadcrumbs/Drop Down Without targets 1`] = `
       >
         <li
           onClick={[Function]}
+          onKeyPress={[Function]}
           role="Menu"
+          tabIndex={0}
         >
           <div
             className="targetContainer"

--- a/src/components/BreadcrumbDropDown/__snapshots__/BreadcrumbDropDown.story.storyshot
+++ b/src/components/BreadcrumbDropDown/__snapshots__/BreadcrumbDropDown.story.storyshot
@@ -22,6 +22,7 @@ exports[`Storyshots Breadcrumbs/Drop Down With targets 1`] = `
         className="breadCrumbBar"
       >
         <li
+          id="breadcrumb-dropdown"
           onClick={[Function]}
           onKeyPress={[Function]}
           role="Menu"
@@ -145,6 +146,7 @@ exports[`Storyshots Breadcrumbs/Drop Down Without targets 1`] = `
         className="breadCrumbBar"
       >
         <li
+          id="breadcrumb-dropdown"
           onClick={[Function]}
           onKeyPress={[Function]}
           role="Menu"

--- a/src/components/BreadcrumbDropDown/index.spec.tsx
+++ b/src/components/BreadcrumbDropDown/index.spec.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { shallow, ShallowWrapper } from 'enzyme';
+
+import ELAG3ClaimMock from '../../../mock_api_data/E.G3.C1';
+import { BreadcrumbDropDown } from '.';
+import { foTarget } from '../../clients/filter/__mocks__';
+
+describe('BreadcrumbDropDown', () => {
+  // tslint:disable: no-any no-unsafe-any
+  let dropdown: ShallowWrapper;
+  beforeEach(() => {
+    dropdown = shallow(
+      <BreadcrumbDropDown
+        targets={foTarget.targetShortCodes}
+        currentTarget={foTarget.targetShortCodes[0]}
+      />
+    );
+  });
+
+  it('Opens the dropdown when clicking', () => {
+    dropdown.find('#breadcrumb-dropdown').simulate('click');
+    expect(dropdown.state('expanded')).toBeTruthy();
+
+    dropdown.find('#breadcrumb-dropdown').simulate('click');
+    expect(dropdown.state('expanded')).toBeFalsy();
+  });
+
+  it('Opens the dropdown when pressing enter', () => {
+    dropdown.find('#breadcrumb-dropdown').simulate('keypress', { key: 'Enter' });
+    expect(dropdown.state('expanded')).toBeTruthy();
+
+    dropdown.find('#breadcrumb-dropdown').simulate('keypress', { key: 'Enter' });
+    expect(dropdown.state('expanded')).toBeFalsy();
+  });
+});

--- a/src/components/BreadcrumbDropDown/index.tsx
+++ b/src/components/BreadcrumbDropDown/index.tsx
@@ -65,7 +65,13 @@ export class BreadcrumbDropDown extends Component<
     return (
       <div className="root">
         <div className="breadCrumbBar">
-          <li onClick={this.onClick} role="Menu" tabIndex={0} onKeyPress={this.handleEnterPress}>
+          <li
+            id="breadcrumb-dropdown"
+            onClick={this.onClick}
+            role="Menu"
+            tabIndex={0}
+            onKeyPress={this.handleEnterPress}
+          >
             <div className="targetContainer" style={style}>
               <div className="targetLabel">{currentTarget.label}</div>
               {showChevron && chevron}

--- a/src/components/BreadcrumbDropDown/index.tsx
+++ b/src/components/BreadcrumbDropDown/index.tsx
@@ -45,6 +45,12 @@ export class BreadcrumbDropDown extends Component<
     this.setState({ expanded });
   };
 
+  handleEnterPress = (e: React.KeyboardEvent<HTMLLIElement>) => {
+    if (e.key === 'Enter') {
+      this.onClick();
+    }
+  };
+
   render() {
     const { currentTarget, targets } = this.props;
     const { expanded } = this.state;
@@ -59,7 +65,7 @@ export class BreadcrumbDropDown extends Component<
     return (
       <div className="root">
         <div className="breadCrumbBar">
-          <li onClick={this.onClick} role="Menu">
+          <li onClick={this.onClick} role="Menu" tabIndex={0} onKeyPress={this.handleEnterPress}>
             <div className="targetContainer" style={style}>
               <div className="targetLabel">{currentTarget.label}</div>
               {showChevron && chevron}

--- a/src/components/Breadcrumbs/Breadcrumbs.story.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.story.tsx
@@ -4,31 +4,18 @@ import { storiesOf } from '@storybook/react';
 import { BrowserRouter } from 'react-router-dom';
 import { Breadcrumbs, BreadcrumbsProps } from './index';
 import { ClaimType, SubjectType } from './BreadcrumbModel';
-
-const emptyMock: BreadcrumbsProps = {};
+import { foTarget } from '../../clients/filter/__mocks__';
 
 const allDataMock: BreadcrumbsProps = {
   subject: SubjectType['English Language Arts'],
   grades: ['8'],
   claim: ClaimType['C4'],
-  target: 'Target 1 and stuff and things this could be really long'
+  target: 'Target 1 and stuff and things this could be really long',
+  targetList: foTarget.targetShortCodes,
+  targetShortCode: 't1'
 };
 
 storiesOf('Breadcrumbs', module)
   .addDecorator(story => <BrowserRouter>{story()}</BrowserRouter>)
-  .add('Default', () => (
-    <Breadcrumbs
-      subject={emptyMock.subject}
-      grades={emptyMock.grades}
-      claim={emptyMock.claim}
-      target={emptyMock.target}
-    />
-  ))
-  .add('Subject, grade, and claim', () => (
-    <Breadcrumbs
-      subject={allDataMock.subject}
-      grades={allDataMock.grades}
-      claim={allDataMock.claim}
-      target={allDataMock.target}
-    />
-  ));
+  .add('Default', () => <Breadcrumbs />)
+  .add('Subject, grade, and claim', () => <Breadcrumbs {...allDataMock} />);

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.story.storyshot
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.story.storyshot
@@ -134,7 +134,7 @@ exports[`Storyshots Breadcrumbs Subject, grade, and claim 1`] = `
         </li>
         <li>
           <a
-            href="/search?subject=ELA"
+            href="/explore?filter=open&subject=ELA"
             onClick={[Function]}
             style={
               Object {
@@ -178,7 +178,7 @@ exports[`Storyshots Breadcrumbs Subject, grade, and claim 1`] = `
         </li>
         <li>
           <a
-            href="/search?grades=8&subject=ELA"
+            href="/explore?filter=open&grades=8&subject=ELA"
             onClick={[Function]}
             style={
               Object {

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -22,6 +22,8 @@ export interface BreadcrumbsProps {
   claim?: string;
   target?: string;
   targetList?: SearchBaseModel[];
+  targetShortCode?: string;
+  claimId?: string;
 }
 
 const isHS = (a: string) => {
@@ -45,7 +47,7 @@ export function buildSearchUrl(subject?: string, grades?: string[], claim?: stri
   };
   const queryString = stringify(query);
 
-  return `/search?${queryString}`;
+  return `/explore?filter=open&${queryString}`;
 }
 
 const background = {
@@ -61,12 +63,10 @@ const background = {
  * @param {ClaimType | undefined} claim
  * @param {string | undefined} target
  */
-export const Breadcrumbs = ({ subject, grades, claim, target, targetList }: BreadcrumbsProps) => {
+export const Breadcrumbs = ({ subject, grades, claim, target, targetList, targetShortCode, claimId }: BreadcrumbsProps) => {
   let currentTarget: SearchBaseModel | undefined;
-  if (target && targetList) {
-    currentTarget = targetList.find(
-      t => t.code === window.location.pathname.replace('/target/', '')
-    );
+  if (targetShortCode && targetList) {
+    currentTarget = targetList.find(t => t.code === targetShortCode);
   }
 
   return (
@@ -93,7 +93,7 @@ export const Breadcrumbs = ({ subject, grades, claim, target, targetList }: Brea
           <MediaQuery {...DesktopBreakSize}>
             {subject && grades && claim && (
               <BreadcrumbLink
-                link={buildSearchUrl(subject, grades, claim)}
+                link={buildSearchUrl(subject, grades, claimId)}
                 value={claim}
                 label="Claim"
               />

--- a/src/components/SearchPage/index.tsx
+++ b/src/components/SearchPage/index.tsx
@@ -28,8 +28,12 @@ export interface SearchPageState {
   pt: boolean;
 }
 
-function anyParams(urlParams: CSESearchQuery): boolean {
+function shouldShowFilter(urlParams: CSESearchQuery): boolean {
   return urlParams.filter ? true : false;
+}
+
+function anyParams(params: CSEFilterParams, search: string) {
+  return search || params.grades.length || params.claim || params.subject || params.target;
 }
 
 function unwrapError<T>(data?: T | Error): T | undefined {
@@ -81,9 +85,13 @@ export class SearchPage extends React.Component<SearchPageProps, SearchPageState
   }
 
   async componentDidMount() {
-    const { filter, ...filterParams } = this.state.params;
-    const options = await this.props.filterClient.getFilterOptions(filterParams);
-    this.setState({ options });
+    const { params, search } = this.state;
+    const options = await this.props.filterClient.getFilterOptions(params);
+    let results: IClaim[] | Error | undefined;
+    if (anyParams(params, search)) {
+      results = await this.props.searchClient.search({search, ...params});
+    }
+    this.setState({ options, results });
   }
 
   private updateQuery(search: string, params: CSEFilterParams) {
@@ -142,7 +150,7 @@ export class SearchPage extends React.Component<SearchPageProps, SearchPageState
           options={options}
           params={params}
           onUpdate={this.onFilterChanged}
-          expanded={anyParams(this.state.params)}
+          expanded={shouldShowFilter(this.state.params)}
           filterPT={this.togglePerformanceTask}
         />
       </ErrorBoundary>

--- a/src/components/TargetDetails/TargetTitleBar/__snapshots__/TargetTitleBar.story.storyshot
+++ b/src/components/TargetDetails/TargetTitleBar/__snapshots__/TargetTitleBar.story.storyshot
@@ -46,7 +46,7 @@ exports[`Storyshots TargetDetails/TargetTitleBar Default 1`] = `
           </li>
           <li>
             <a
-              href="/search?subject=English%20Language%20Arts"
+              href="/explore?filter=open&subject=English%20Language%20Arts"
               onClick={[Function]}
               style={
                 Object {
@@ -90,7 +90,7 @@ exports[`Storyshots TargetDetails/TargetTitleBar Default 1`] = `
           </li>
           <li>
             <a
-              href="/search?grades=6&subject=English%20Language%20Arts"
+              href="/explore?filter=open&grades=6&subject=English%20Language%20Arts"
               onClick={[Function]}
               style={
                 Object {

--- a/src/components/TargetDetails/TargetTitleBar/index.tsx
+++ b/src/components/TargetDetails/TargetTitleBar/index.tsx
@@ -38,7 +38,9 @@ export const parseBreadCrumbData = (
     subject: claim.subject,
     grades: claim.grades,
     claim: claimTitle,
-    target: claim.target[0].title
+    target: claim.target[0].title,
+    targetShortCode: claim.target[0].shortCode,
+    claimId: claim.claimNumber
   };
 };
 export const parseDownloadBtnProps = (claim: IClaim): DownloadBtnProps => {

--- a/src/components/TargetDetails/__mocks__/index.ts
+++ b/src/components/TargetDetails/__mocks__/index.ts
@@ -162,7 +162,9 @@ export const parsedBreadCrumbDataMock: BreadcrumbsProps = {
   grades: ['6'],
   claim: 'Claim 1',
   target: 'English Language Arts Specification: Grade 6 Claim 1 Target 1',
-  targetList: undefined
+  targetList: undefined,
+  targetShortCode: 'E.G6.C1RL.T1',
+  claimId: 'C1'
 };
 
 export const parsedTitleBarDataMock: TitleBarProps = {
@@ -177,7 +179,7 @@ export const parsedTitleBarDataMock: TitleBarProps = {
 };
 export const parsedMobileTitleBarDataMock: MobileTitleBarProps = {
   claimTitle: 'Claim 1',
-  claimUrl: '/search?claim=C1&grades=6&subject=English%20Language%20Arts',
+  claimUrl: '/explore?filter=open&claim=C1&grades=6&subject=English%20Language%20Arts',
   targetTitle: 'Target 1',
   downloadBtnProps: {
     claim: ELAG3ClaimMock

--- a/src/components/TitleBar/DownloadBtn.spec.tsx
+++ b/src/components/TitleBar/DownloadBtn.spec.tsx
@@ -19,6 +19,11 @@ describe('DownloadModal', () => {
     expect(downloadBtn.state('modal')).toEqual(mockModal);
   });
 
+  it('Opens the modal when pressing enter key', () => {
+    downloadBtn.find('#download-btn').simulate('keypress', { key: 'Enter' });
+    expect(downloadBtn.state('modal')).toEqual(mockModal);
+  });
+
   it('closes the modal on esc', () => {
     downloadBtn.find('#download-btn').simulate('keyDown', {
       keyCode: 27

--- a/src/components/TitleBar/DownloadBtn.tsx
+++ b/src/components/TitleBar/DownloadBtn.tsx
@@ -38,16 +38,31 @@ export class DownloadBtn extends Component<DownloadBtnProps, DownloadBtnState> {
       }
     };
   }
+
   showHideModal = () => {
     const curModal = this.state.modal;
     curModal.isOpen = !this.state.modal.isOpen;
     this.setState({ modal: curModal });
   };
+
+  handleEnterPress = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
+    if (e.key === 'Enter') {
+      this.showHideModal();
+    }
+  };
+
   render() {
     return (
       <div id="download-btn-container">
         <DownloadModal {...this.state.modal} closeFromParent={this.showHideModal} />
-        <a aria-label="Download" role="button" onClick={this.showHideModal} id="download-btn">
+        <a
+          aria-label="Download"
+          role="button"
+          onClick={this.showHideModal}
+          id="download-btn"
+          tabIndex={0}
+          onKeyPress={this.handleEnterPress}
+        >
           {/* tslint:disable-next-line:no-unsafe-any */}
           <FontAwesomeIcon className="cloud" icon={faCloudDownloadAlt} />
         </a>

--- a/src/components/TitleBar/__snapshots__/TitleBar.story.storyshot
+++ b/src/components/TitleBar/__snapshots__/TitleBar.story.storyshot
@@ -46,7 +46,9 @@ exports[`Storyshots TitleBar component Renders a Title Bar with a claim only 1`]
             aria-label="Download"
             id="download-btn"
             onClick={[Function]}
+            onKeyPress={[Function]}
             role="button"
+            tabIndex={0}
           >
             <svg
               aria-hidden="true"
@@ -235,7 +237,9 @@ exports[`Storyshots TitleBar component Renders a Title Bar with all data 1`] = `
             aria-label="Download"
             id="download-btn"
             onClick={[Function]}
+            onKeyPress={[Function]}
             role="button"
+            tabIndex={0}
           >
             <svg
               aria-hidden="true"
@@ -479,7 +483,9 @@ exports[`Storyshots TitleBar component Renders a download button 1`] = `
         aria-label="Download"
         id="download-btn"
         onClick={[Function]}
+        onKeyPress={[Function]}
         role="button"
+        tabIndex={0}
       >
         <svg
           aria-hidden="true"

--- a/src/components/TitleBar/__snapshots__/mobileTitleBar.story.storyshot
+++ b/src/components/TitleBar/__snapshots__/mobileTitleBar.story.storyshot
@@ -33,7 +33,9 @@ exports[`Storyshots Mobile TitleBar component Renders a Title Bar with a claim o
               aria-label="Download"
               id="download-btn"
               onClick={[Function]}
+              onKeyPress={[Function]}
               role="button"
+              tabIndex={0}
             >
               <svg
                 aria-hidden="true"
@@ -179,7 +181,9 @@ exports[`Storyshots Mobile TitleBar component Renders a Title Bar with all data 
               aria-label="Download"
               id="download-btn"
               onClick={[Function]}
+              onKeyPress={[Function]}
               role="button"
+              tabIndex={0}
             >
               <svg
                 aria-hidden="true"
@@ -371,7 +375,9 @@ exports[`Storyshots Mobile TitleBar component Renders a download button 1`] = `
         aria-label="Download"
         id="download-btn"
         onClick={[Function]}
+        onKeyPress={[Function]}
         role="button"
+        tabIndex={0}
       >
         <svg
           aria-hidden="true"


### PR DESCRIPTION
# Changes introduced
- updated the url breadcrumb links pointed to
- cleaned up unnecessary [non pure](https://en.wikipedia.org/wiki/Pure_function ) call in breadcrumbs functional component
- load search results when navigating to search page with params or query string
- keyboard accessibility for breadcrumb dropdown and download modal

## Related issue(s):

- https://sbacjira.atlassian.net/browse/CSE-432
- https://sbacjira.atlassian.net/browse/CSE-426

## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [x] Added new stories for created/modified components (if applicable)
- [x] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [x] Verified that there are no issues in CircleCI
- [x] Assigned yourself to the PR
- [x] Removed `WIP:` from the PR title
- [x] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
