### PR TITLE
feat(sortmodels): task models are sorted in correct order for all pages

### DIFF
--- a/src/components/TargetDetails/index.tsx
+++ b/src/components/TargetDetails/index.tsx
@@ -35,11 +35,17 @@ function stemSection(stem: IStem[]): ContentSection[] {
   return sections;
 }
 
+export const SortTaskModels = (a: ITaskModel, b: ITaskModel) =>
+  parseInt(a.taskName.replace('Task Model ', ''), 10) -
+  parseInt(b.taskName.replace('Task Model ', ''), 10);
+
 function taskModelSections(
   taskModels: ITaskModel[],
   stem?: IStem[],
   isMath?: boolean
 ): ContentSection[] {
+  taskModels.sort(SortTaskModels);
+
   return taskModels.map((tm, i) => {
     let subsections: ContentSection[] = [];
 
@@ -84,8 +90,8 @@ function taskModelSections(
 }
 
 function fillValidSection(section: string, sections: ContentSection[], title: string) {
-  if(section) {
-   sections.push({
+  if (section) {
+    sections.push({
       title,
       jsx: parseContent(section)
     });
@@ -105,11 +111,11 @@ function setUpTargetSections(target: ITarget, sections: ContentSection[]) {
       title: 'Stimuli/Text Complexity',
       jsx: undefined
     });
-    const subsects: ContentSection []= [];
+    const subsects: ContentSection[] = [];
     fillValidSection(target.stimInfo, subsects, 'Passage');
     fillValidSection(target.dualText, subsects, 'Dual Text');
     fillValidSection(target.complexity, subsects, 'Text Complexity');
-    sections[sections.length-1].subsections=subsects;
+    sections[sections.length - 1].subsections = subsects;
   }
   fillValidSection(target.accessibility, sections, 'Accessibility Guidelines');
 


### PR DESCRIPTION
# Changes introduced

Task Models were not sorted in order on the content nav. Now they are!

## Related issue(s):

- CSE-431_

## Contributor checklist

- [x] Wrote/updated tests for introduced changes
- [ ] Added new stories for created/modified components (if applicable)
- [ ] Checked Storybook for Accessibility issues (if applicable)
- [ ] ~~Updated Postman library for created/modified routes (if applicable)~~
- [ ] Verified that there are no issues in CircleCI
- [ ] Assigned yourself to the PR
- [ ] Removed `WIP:` from the PR title
- [ ] Requested review from the SB Reviewers team

## Reviewer checklist

- [ ] Assigned yourself to the PR
- [ ] Read through the changes in the `Files changed` tab
- [ ] Verified that tests were written/modified
- [ ] Verified that stories were written/modified (if applicable)
- [ ] ~~Verified that Postman was updated (if applicable)~~
- [ ] Checked out the branch and tested changes locally
- [ ] Run storybook and checked that there are no accessibility issues
